### PR TITLE
Prevent silent failure if curl can't handle sub-second timeouts

### DIFF
--- a/get_region_and_token.sh
+++ b/get_region_and_token.sh
@@ -80,6 +80,13 @@ bestRegion="$(echo "$summarized_region_data" |
   xargs -i bash -c 'printServerLatency {}' |
   sort | head -1 | awk '{ print $2 }')"
 
+# test if we got any valid results
+if ! grep -q '[[:alnum:]]' <<< "$bestRegion"; then
+	echo "No region responded within ${maximum_allowed_latency}s, consider using a higher timeout"
+	echo "Example: $ maximum_allowed_latency=1 $0"
+	exit 1
+fi
+
 # Get all data for the best region
 regionData="$( echo $all_region_data |
   jq --arg REGION_ID "$bestRegion" -r \

--- a/get_region_and_token.sh
+++ b/get_region_and_token.sh
@@ -27,6 +27,15 @@
 maximum_allowed_latency=0.05
 export maximum_allowed_latency
 
+# test if curl accepts timeouts below 1s - see https://github.com/curl/curl/blob/master/lib/hostip.c#L700
+curl -s --connect-timeout 0.999 -m 1 255.255.255.255 &>/dev/null
+if [ $? -eq 28 ]
+then
+  echo "Your system's curl doesn't accept timeouts below 1 second"
+  echo "Altering maximum_allowed_latency to 1s"
+  export maximum_allowed_latency=1
+fi
+
 serverlist_url='https://serverlist.piaservers.net/vpninfo/servers/v4'
 
 # This function checks the latency you have to a specific region.


### PR DESCRIPTION
get_region_and_token was spitting out nonsense for me:

```
Getting the server list... OK!
Testing regions that respond faster than 0.05 seconds:
The closest region is .

The script found the best servers from the region closest to you.
When connecting to an IP (no matter which protocol), please verify
the SSL/TLS certificate actually contains the hostname so that you
are sure you are connecting to a secure server, validated by the
PIA authority. Please find bellow the list of best IPs and matching
hostnames for each protocol:
Meta Services:  // 
WireGuard:  // 
OpenVPN TCP:  // 
OpenVPN UDP:  // 
```

Turns out, curl doesn't like timeouts below 1 second unless it's recompiled to not use the system resolver - see https://github.com/curl/curl/blob/master/lib/hostip.c#L700

This pull detects this case, and updates the maximum latency to 1 second so curl (and thus get_region_and_token) doesn't simply silently fail.

I tried doing some trickiness with `( bash -c 'sleep $maximum_allowed_latency && kill $$ & curl ...' )` but unfortunately it didn't work out too well.

When passed `--connect-timeout 0.999 255.255.255.255`, curl returns `28` if it doesn't accept the timeout, or `7` if it accepts the timeout but can't connect to `255.255.255.255`. I added `-m 1` as a sanity check in case something even weirder happens on someone's system.