### PR TITLE
Check more things

### DIFF
--- a/connect_to_wireguard_with_token.sh
+++ b/connect_to_wireguard_with_token.sh
@@ -23,10 +23,12 @@
 
 # PIA currently does not support IPv6. In order to be sure your VPN
 # connection does not leak, it is best to disabled IPv6 altogether.
-echo 'You should consider disabling IPv6 by running:
-sysctl -w net.ipv6.conf.all.disable_ipv6=1
-sysctl -w net.ipv6.conf.default.disable_ipv6=1
-'
+if [ $(sysctl -n net.ipv6.conf.all.disable_ipv6) -ne 1 ] || [ $(sysctl -n net.ipv6.conf.default.disable_ipv6) -ne 1 ]
+then
+  echo 'You should consider disabling IPv6 by running:'
+  echo 'sysctl -w net.ipv6.conf.all.disable_ipv6=1'
+  echo 'sysctl -w net.ipv6.conf.default.disable_ipv6=1'
+fi
 
 # so we can print more than one error about missing tools in a single run
 EXIT=0

--- a/connect_to_wireguard_with_token.sh
+++ b/connect_to_wireguard_with_token.sh
@@ -28,12 +28,31 @@ sysctl -w net.ipv6.conf.all.disable_ipv6=1
 sysctl -w net.ipv6.conf.default.disable_ipv6=1
 '
 
+# so we can print more than one error about missing tools in a single run
+EXIT=0
+
 # check if the wireguard tools have been installed
 if ! command -v wg-quick &> /dev/null
 then
     echo "wg-quick could not be found."
     echo "Please install wireguard-tools"
-    exit 1
+    EXIT=1
+fi
+
+# check if curl has been installed
+if ! command -v curl &> /dev/null
+then
+    echo "curl could not be found."
+    echo "Please install curl"
+    EXIT=1
+fi
+
+# check if jq has been installed
+if ! command -v jq &> /dev/null
+then
+    echo "jq could not be found."
+    echo "Please install jq"
+    EXIT=1
 fi
 
 # Check if the mandatory environment variables are set.
@@ -51,7 +70,13 @@ if [[ ! $WG_SERVER_IP || ! $WG_HOSTNAME || ! $WG_TOKEN ]]; then
   echo as it will guide you through getting the best server and 
   echo also a token. Detailed information can be found here:
   echo https://github.com/pia-foss/manual-connections
-  exit 1
+  EXIT=1
+fi
+
+# exit if any required tools are missing
+if [ $EXIT -ne 0 ]
+then
+  exit $EXIT
 fi
 
 # Create ephemeral wireguard keys, that we don't need to save to disk.

--- a/connect_to_wireguard_with_token.sh
+++ b/connect_to_wireguard_with_token.sh
@@ -33,29 +33,25 @@ fi
 # so we can print more than one error about missing tools in a single run
 EXIT=0
 
+function check_tool() {
+	COMMAND=$1
+	PACKAGE=$2
+	if ! command -v $COMMAND &>/dev/null
+	then
+		echo "$COMMAND could not be found"
+		echo "Please install $PACKAGE"
+	fi
+	EXIT=1
+}
+
 # check if the wireguard tools have been installed
-if ! command -v wg-quick &> /dev/null
-then
-    echo "wg-quick could not be found."
-    echo "Please install wireguard-tools"
-    EXIT=1
-fi
+check_tool wg-quick wireguard-tools
 
 # check if curl has been installed
-if ! command -v curl &> /dev/null
-then
-    echo "curl could not be found."
-    echo "Please install curl"
-    EXIT=1
-fi
+check_tool curl curl
 
 # check if jq has been installed
-if ! command -v jq &> /dev/null
-then
-    echo "jq could not be found."
-    echo "Please install jq"
-    EXIT=1
-fi
+check_tool jq jq
 
 # Check if the mandatory environment variables are set.
 if [[ ! $WG_SERVER_IP || ! $WG_HOSTNAME || ! $WG_TOKEN ]]; then

--- a/connect_to_wireguard_with_token.sh
+++ b/connect_to_wireguard_with_token.sh
@@ -112,6 +112,7 @@ fi
 # have resolvconf, which will result in the script failing.
 # We will enforce the DNS after the connection gets established.
 echo -n "Trying to write /etc/wireguard/pia.conf... "
+mkdir -p /etc/wireguard
 echo "
 [Interface]
 Address = $(echo "$wireguard_json" | jq -r '.peer_ip')

--- a/get_region_and_token.sh
+++ b/get_region_and_token.sh
@@ -24,8 +24,8 @@
 # Set this to the maximum allowed latency in seconds.
 # All servers that repond slower than this will be ignore.
 # The default value is 50 milliseconds.
-maximum_allowed_latency=${maximum_allowed_latency:-0.05}
-export maximum_allowed_latency
+MAX_LATENCY=${MAX_LATENCY:-0.05}
+export MAX_LATENCY
 
 serverlist_url='https://serverlist.piaservers.net/vpninfo/servers/v4'
 
@@ -38,7 +38,7 @@ printServerLatency() {
   regionName="$(echo ${@:3} |
     sed 's/ false//' | sed 's/true/(geo)/')"
   time=$(curl -o /dev/null -s \
-    --connect-timeout $maximum_allowed_latency \
+    --connect-timeout $MAX_LATENCY \
     --write-out "%{time_connect}" \
     http://$serverIP:443)
   if [ $? -eq 0 ]; then
@@ -66,7 +66,7 @@ echo "OK!"
 summarized_region_data="$( echo $all_region_data |
   jq -r '.regions[] | .servers.meta[0].ip+" "+.id+" "+.name+" "+(.geo|tostring)' )"
 echo Testing regions that respond \
-  faster than $maximum_allowed_latency seconds:
+  faster than $MAX_LATENCY seconds:
 bestRegion="$(echo "$summarized_region_data" |
   xargs -i bash -c 'printServerLatency {}' |
   sort | head -1 | awk '{ print $2 }')"

--- a/get_region_and_token.sh
+++ b/get_region_and_token.sh
@@ -23,8 +23,8 @@
 
 # Set this to the maximum allowed latency in seconds.
 # All servers that repond slower than this will be ignore.
-# The value is currently set to 50 milliseconds.
-maximum_allowed_latency=0.05
+# The default value is 50 milliseconds.
+maximum_allowed_latency=${maximum_allowed_latency:-0.05}
 export maximum_allowed_latency
 
 serverlist_url='https://serverlist.piaservers.net/vpninfo/servers/v4'


### PR DESCRIPTION
* `connect_to_wireguard_with_token.sh` only checks for the existence of `wg-quick`, but not `jq` or `curl`.

  [commit #1](../commit/0867a3e0e4c2294ed60a24ab29c4d60021dd6dc6) in this pull fixes that - with the added feature that it will complain about _all_ missing tools in a single invocation.

* `connect_to_wireguard_with_token.sh` attempts to write to `/etc/wireguard/pia.conf` without checking if `/etc/wireguard` exists

  [commit #2](../commit/1788dd58a35ae72fa72bdfb948e4e8b54dae13f8) in this pull fixes that with a simple `mkdir -p /etc/wireguard`

* `connect_to_wireguard_with_token.sh` complains about ipv6 being enabled even if it's already been disabled as per the script's suggestion

  [commit #3](../commit/5893acbba462655baf23ab28115bc74cdccfe8f8) only warns about ipv6 if the suggestion hasn't been heeded

* `get_region_and_token.sh` doesn't provide a way to externally specify the maximum latency

  [commit #4](../commit/1e9e09c36a7a9c9f2f35f7ce0db4aaac826025a0) allows the default `maximum_allowed_latency` to be overridden by an external environment variable.