### PR TITLE
Allow curl to request user password, to prevent exposing it via /proc…

### DIFF
--- a/get_region_and_token.sh
+++ b/get_region_and_token.sh
@@ -136,6 +136,10 @@ echo "$generateTokenResponse"
 
 if [ "$(echo "$generateTokenResponse" | jq -r '.status')" != "OK" ]; then
   echo "Could not get a token. Please check your account credentials."
+  echo "You can also try debugging by manually running the curl command:"
+  echo $ curl -vs -u "username:password" --cacert ca.rsa.4096.crt \
+    --connect-to "$bestServer_meta_hostname::$bestServer_meta_IP:" \
+    https://$bestServer_meta_hostname/authv3/generateToken
   exit 1
 fi
 


### PR DESCRIPTION
Environment variables passed into a script are visible via `/proc/*/env`.

Calling curl with `-u "$USER:$PASS"` makes the password visible in `ps ax`.

Curl's manual says that it rapidly removes this information from that table, however there's still a brief window where the password could be leaked.

This pull allows curl _itself_ to request the user's password, preventing it being leaked via either of those vectors.

This pull also retains the previous functionality, to support users who trust that these password leak vectors aren't part of their attack surface.

Explanatory output from the script has also been updated to reflect this change.

I also added `-S` (`--show-error`) to curl so that it can output errors by itself rather than asking the user to re-run curl manually to see them.