### PR TITLE
- The following changes allow this script to work on OpenWRT and othe…

### DIFF
--- a/connect_to_wireguard_with_token.sh
+++ b/connect_to_wireguard_with_token.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Copyright (C) 2020 Private Internet Access, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -37,16 +37,14 @@ check_tool jq jq
 
 # PIA currently does not support IPv6. In order to be sure your VPN
 # connection does not leak, it is best to disabled IPv6 altogether.
-if [ $(sysctl -n net.ipv6.conf.all.disable_ipv6) -ne 1 ] ||
-  [ $(sysctl -n net.ipv6.conf.default.disable_ipv6) -ne 1 ]
-then
+if [ "$(sysctl -n net.ipv6.conf.all.disable_ipv6)" -ne 1 -o "$(sysctl -n net.ipv6.conf.default.disable_ipv6)" -ne 1 ]; then
   echo 'You should consider disabling IPv6 by running:'
   echo 'sysctl -w net.ipv6.conf.all.disable_ipv6=1'
   echo 'sysctl -w net.ipv6.conf.default.disable_ipv6=1'
 fi
 
 # Check if the mandatory environment variables are set.
-if [[ ! $WG_SERVER_IP || ! $WG_HOSTNAME || ! $WG_TOKEN ]]; then
+if [ -z "${WG_SERVER_IP}" -o -z "${WG_HOSTNAME}" -o -z "${WG_TOKEN}" ]; then
   echo This script requires 3 env vars:
   echo WG_SERVER_IP - IP that you want to connect to
   echo WG_HOSTNAME  - name of the server, required for ssl
@@ -125,7 +123,7 @@ At this point, internet should work via VPN.
 $ wg-quick down pia"
 
 # This section will stop the script if PIA_PF is not set to "true".
-if [ "$PIA_PF" != true ]; then
+if [ "$PIA_PF" != "true" ]; then
   echo
   echo If you want to also enable port forwarding, please start the script
   echo with the env var PIA_PF=true. Example:

--- a/get_region_and_token.sh
+++ b/get_region_and_token.sh
@@ -92,7 +92,7 @@ fi
 echo Testing regions that respond \
   faster than $MAX_LATENCY seconds:
 bestRegion="$(echo "$summarized_region_data" |
-  xargs -i bash -c 'printServerLatency {}' |
+  xargs -I{} bash -c 'printServerLatency {}' |
   sort | head -1 | awk '{ print $2 }')"
 
 if [ -z "$bestRegion" ]; then

--- a/port_forwarding.sh
+++ b/port_forwarding.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Copyright (C) 2020 Private Internet Access, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -21,7 +21,7 @@
 
 
 # Check if the mandatory environment variables are set.
-if [[ ! $PF_GATEWAY || ! $PIA_TOKEN ]]; then
+if [ -z "${PF_GATEWAY}" -o -z "${PIA_TOKEN}" ]; then
   echo This script requires 3 env vars:
   echo PF_GATEWAY  - the IP of your gateway
   echo PF_HOSTNAME - name of the host used for SSL/TLS certificate verification
@@ -54,7 +54,7 @@ fi
 # If you already have a signature, and you would like to re-use that port,
 # save the payload_and_signature received from your previous request
 # in the env var PAYLOAD_AND_SIGNATURE, and that will be used instead.
-if [[ ! $PAYLOAD_AND_SIGNATURE ]]; then
+if [ -z "${PAYLOAD_AND_SIGNATURE}" ]; then
   echo "Getting new signature..."
   payload_and_signature="$(curl -s -m 5 \
     --connect-to "$PF_HOSTNAME::$PF_GATEWAY:" \


### PR DESCRIPTION
- Shell script get_region_and_token.sh
  - Should fix issue #5  . At least for this particular script.

- The following changes allow this script to work on OpenWRT with no loss of functionality.
  - A few changes to make the script compatible with most shell interpreter implementations.
    - Not only bash(1).
- Furthermore, only use features available on limited shell interpreter implementations such as  the one on OpenWRT

- Detailed description follows:
  - On function printServerLatency:
    - Replace "${@:3}" with "shift 2"
      - Feature is not widely available and it can be replaced with shift
    - Do not spawn 2 sed when a single one will do.
    - Suggestion:
      - Add "--max-time $((${MAX_LATENCY} * 2))" to curl: The whole process (from connection to transmission) should not take more than MAX_LATENCY * 2
  - Remove "export -f printServerLatency"
    - Function export feature is not widely available and it will not be required due to change on variable bestRegion instantiation
  - Replace "[[ ... ]]" with widely available "[ ]" from test(1).
    - Use test(1) syntax for the replaced tests: -lt, -o and -z.
  - On summarized_region_data:
    - Make it easier to modify the jq processing string.
      - Like a construct pattern.
    - Suggestion:
      - Add "PIA_NO_GEO" env variable to filter out geo virtual locations.
  - On bestRegion:
    - Limitted shell environments (such as on OpenWRT) do not support "xargs -i".
    - Furthermore, function export feature is not widely available.
    - Therefore, use a more compatible construct. It also does not spawn a process per line.
      - Replace
        "xargs -i bash -c 'printServerLatency {}'"
      with
        "{ while read -r LINE ; do printServerLatency ${LINE} ; done }"
    - Replace "sort" with "sort -n" since we are dealing with numbers.
  - Add instructions for "PIA_NO_GEO" env variable