### PR TITLE
Small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The functionality of the scripts within this repository has been tested and conf
 
 ## PIA Port Forwarding
 
-The PIA Port Forwarding service (a.k.a. PF) allows you run services on your own devices, and expose them to the internet by using the PIA VPN Network. The easiest way to set this up is by using a native PIA aplications. In case you require port forwarding on native clients, please follow this documentation in order to enable port forwarding for your VPN connection.
+The PIA Port Forwarding service (a.k.a. PF) allows you run services on your own devices, and expose them to the internet by using the PIA VPN Network. The easiest way to set this up is by using a native PIA aplication. In case you require port forwarding on native clients, please follow this documentation in order to enable port forwarding for your VPN connection.
 
 This service can be used only AFTER establishing a VPN connection.
 
@@ -54,7 +54,7 @@ Here is a list of scripts you could find useful:
 
 To use port forwarding on the NextGen network, first of all establish a connection with your favorite protocol. After this, you will need to find the private IP of the gateway you are connected to. In case you are WireGuard, the gateway will be part of the JSON response you get from the server, as you can see in the [bash script](https://github.com/pia-foss/manual-connections/blob/master/wireguard_and_pf.sh#L119). In case you are using OpenVPN, you can find the gateway by checking the routing table with `ip route s t all`.
 
-After connecting and finding out what the gateway is, get your payload and your signature by calling `getSignature` via HTTPS on port 19999. You will have to add your token as a GET var to proove you actually have an active account.
+After connecting and finding out what the gateway is, get your payload and your signature by calling `getSignature` via HTTPS on port 19999. You will have to add your token as a GET var to prove you actually have an active account.
 
 Example:
 ```bash

--- a/connect_to_openvpn_with_token.sh
+++ b/connect_to_openvpn_with_token.sh
@@ -41,7 +41,7 @@ adapter_check="$( ip a s tun06 )"
 should_read="Device \"tun06\" does not exist"
 pid_filepath="/opt/piavpn-manual/pia_pid"
 if [[ "$adapter_check" != "$should_read" ]]; then
-  echo The tun06 adapter already exists, that interface is required 
+  echo The tun06 adapter already exists, that interface is required
   echo for this configuration.
   if [ -f "$pid_filepath" ]; then
     old_pid="$( cat "$pid_filepath" )"
@@ -95,7 +95,7 @@ if [[ ! $OVPN_SERVER_IP ||
   echo "PAYLOAD_AND_SIGNATURE - In case you already have a port."
   echo
   echo An easy solution is to just run get_region_and_token.sh
-  echo as it will guide you through getting the best server and 
+  echo as it will guide you through getting the best server and
   echo also a token. Detailed information can be found here:
   echo https://github.com/pia-foss/manual-connections
   exit 1
@@ -139,7 +139,7 @@ fi
 cat $prefix_filepath > /opt/piavpn-manual/pia.ovpn || exit 1
 echo remote $OVPN_SERVER_IP $port $protocol >> /opt/piavpn-manual/pia.ovpn
 
-# Copy the up/down scripts to /opt/piavpn-manual/ 
+# Copy the up/down scripts to /opt/piavpn-manual/
 # based upon use of PIA DNS
 if [ "$PIA_DNS" != true ]; then
   cp openvpn_config/openvpn_up.sh /opt/piavpn-manual/
@@ -203,7 +203,7 @@ At this point, internet should work via VPN.
 echo "OpenVPN Process ID: $ovpn_pid
 VPN route IP: $gateway_ip
 
-To disconnect the VPN, run: 
+To disconnect the VPN, run:
 
 --> sudo kill $ovpn_pid <--
 "

--- a/connect_to_openvpn_with_token.sh
+++ b/connect_to_openvpn_with_token.sh
@@ -34,7 +34,7 @@ check_tool curl
 check_tool jq
 check_tool openvpn
 
-# Check if manual PIA OpenVPN connection is alread intitialized.
+# Check if manual PIA OpenVPN connection is already initialized.
 # Multi-hop is out of the scope of this repo, but you should be able to
 # get multi-hop running with both OpenVPN and WireGuard.
 adapter_check="$( ip a s tun06 )"
@@ -158,7 +158,7 @@ fi
 # Start the OpenVPN interface.
 # If something failed, stop this script.
 # If you get DNS errors because you miss some packages,
-# just can hardcode /etc/resolv.conf to "nameserver 10.0.0.242".
+# just hardcode /etc/resolv.conf to "nameserver 10.0.0.242".
 #rm -f /opt/piavpn-manual/debug_info
 echo "
 Trying to start the OpenVPN connection..."
@@ -172,8 +172,8 @@ The OpenVPN connect command was issued.
 
 Confirming OpenVPN connection state... "
 
-# Check if manual PIA OpenVPN connection is intitialized.
-# Manually adjust the connectino_wait_time if needed
+# Check if manual PIA OpenVPN connection is initialized.
+# Manually adjust the connection_wait_time if needed
 connection_wait_time=10
 confirmation="Initialization Sequence Complete"
 for (( timeout=0; timeout <=$connection_wait_time; timeout++ ))

--- a/connect_to_wireguard_with_token.sh
+++ b/connect_to_wireguard_with_token.sh
@@ -126,7 +126,7 @@ echo OK!
 # Start the WireGuard interface.
 # If something failed, stop this script.
 # If you get DNS errors because you miss some packages,
-# just can hardcode /etc/resolv.conf to "nameserver 10.0.0.242".
+# just hardcode /etc/resolv.conf to "nameserver 10.0.0.242".
 echo
 echo Trying to create the wireguard interface...
 wg-quick up pia || exit 1

--- a/connect_to_wireguard_with_token.sh
+++ b/connect_to_wireguard_with_token.sh
@@ -57,7 +57,7 @@ if [[ ! $WG_SERVER_IP || ! $WG_HOSTNAME || ! $PIA_TOKEN ]]; then
   echo "PAYLOAD_AND_SIGNATURE - In case you already have a port."
   echo
   echo An easy solution is to just run get_region_and_token.sh
-  echo as it will guide you through getting the best server and 
+  echo as it will guide you through getting the best server and
   echo also a token. Detailed information can be found here:
   echo https://github.com/pia-foss/manual-connections
   exit 1
@@ -127,7 +127,7 @@ echo OK!
 # If something failed, stop this script.
 # If you get DNS errors because you miss some packages,
 # just can hardcode /etc/resolv.conf to "nameserver 10.0.0.242".
-echo 
+echo
 echo Trying to create the wireguard interface...
 wg-quick up pia || exit 1
 echo "The WireGuard interface got created.

--- a/get_region_and_token.sh
+++ b/get_region_and_token.sh
@@ -109,9 +109,9 @@ regionData="$( echo $all_region_data |
   '.regions[] | select(.id==$REGION_ID)')"
 
 echo -n The closest region is "$(echo $regionData | jq -r '.name')"
-if echo $regionData | jq -r '.geo' | grep true > /dev/null; then 
+if echo $regionData | jq -r '.geo' | grep true > /dev/null; then
   echo " (geolocated region)."
-else 
+else
   echo "."
 fi
 echo

--- a/get_region_and_token.sh
+++ b/get_region_and_token.sh
@@ -67,7 +67,7 @@ echo -n "Getting the server list... "
 all_region_data=$(curl -s "$serverlist_url" | head -1)
 
 # If the server list has less than 1000 characters, it means curl failed.
-if [[ ${#all_region_data} < 1000 ]]; then
+if [[ ${#all_region_data} -lt 1000 ]]; then
   echo "Could not get correct region data. To debug this, run:"
   echo "$ curl -v $serverlist_url"
   echo "If it works, you will get a huge JSON as a response."

--- a/get_region_and_token.sh
+++ b/get_region_and_token.sh
@@ -35,7 +35,7 @@ check_tool curl curl
 check_tool jq jq
 
 # This allows you to set the maximum allowed latency in seconds.
-# All servers that repond slower than this will be ignored.
+# All servers that respond slower than this will be ignored.
 # You can inject this with the environment variable MAX_LATENCY.
 # The default value is 50 milliseconds.
 MAX_LATENCY=${MAX_LATENCY:-0.05}
@@ -63,7 +63,7 @@ printServerLatency() {
 export -f printServerLatency
 
 echo -n "Getting the server list... "
-# Get all region data since we will need this on multiple ocasions
+# Get all region data since we will need this on multiple occasions
 all_region_data=$(curl -s "$serverlist_url" | head -1)
 
 # If the server list has less than 1000 characters, it means curl failed.

--- a/openvpn_config/standard.ovpn
+++ b/openvpn_config/standard.ovpn
@@ -1,18 +1,18 @@
 client
 dev tun06
-resolv-retry infinite 
-nobind 
-persist-key 
-persist-tun 
-cipher aes-128-cbc 
-auth sha1 
-tls-client 
+resolv-retry infinite
+nobind
+persist-key
+persist-tun
+cipher aes-128-cbc
+auth sha1
+tls-client
 remote-cert-tls server
-	
-auth-user-pass /opt/piavpn-manual/credentials 
-compress 
-verb 1 
-reneg-sec 0 
+
+auth-user-pass /opt/piavpn-manual/credentials
+compress
+verb 1
+reneg-sec 0
 
 <ca>
 -----BEGIN CERTIFICATE-----

--- a/openvpn_config/strong.ovpn
+++ b/openvpn_config/strong.ovpn
@@ -1,18 +1,18 @@
 client
 dev tun06
-resolv-retry infinite 
-nobind 
-persist-key 
-persist-tun 
-cipher aes-256-cbc 
-auth sha256 
-tls-client 
+resolv-retry infinite
+nobind
+persist-key
+persist-tun
+cipher aes-256-cbc
+auth sha256
+tls-client
 remote-cert-tls server
-	
-auth-user-pass /opt/piavpn-manual/credentials 
-compress 
-verb 1 
-reneg-sec 0 
+
+auth-user-pass /opt/piavpn-manual/credentials
+compress
+verb 1
+reneg-sec 0
 
 <ca>
 -----BEGIN CERTIFICATE-----

--- a/port_forwarding.sh
+++ b/port_forwarding.sh
@@ -28,7 +28,7 @@ if [[ ! $PF_GATEWAY || ! $PIA_TOKEN || ! $PF_HOSTNAME ]]; then
   echo PIA_TOKEN   - the token you use to connect to the vpn services
   echo
   echo An easy solution is to just run get_region_and_token.sh
-  echo as it will guide you through getting the best server and 
+  echo as it will guide you through getting the best server and
   echo also a token. Detailed information can be found here:
   echo https://github.com/pia-foss/manual-connections
 exit 1

--- a/port_forwarding.sh
+++ b/port_forwarding.sh
@@ -80,7 +80,7 @@ fi
 signature="$(echo "$payload_and_signature" | jq -r '.signature')"
 
 # The payload has a base64 format. We need to extract it from the
-# previous reponse and also get the following information out:
+# previous response and also get the following information out:
 # - port: This is the port you got access to
 # - expires_at: this is the date+time when the port expires
 payload="$(echo "$payload_and_signature" | jq -r '.payload')"

--- a/run_setup.sh
+++ b/run_setup.sh
@@ -82,7 +82,7 @@ export PIA_AUTOCONNECT
 echo PIA_AUTOCONNECT=$PIA_AUTOCONNECT"
 "
 
-# Check for the required presence of resolvconf for settnig DNS on wireguard connections.
+# Check for the required presence of resolvconf for setting DNS on wireguard connections.
 setDNS="yes"
 if ! command -v resolvconf &>/dev/null && [ "$PIA_AUTOCONNECT" == wireguard ]; then
   echo The resolvconf package could not be found.
@@ -119,7 +119,7 @@ export PIA_PF
 echo PIA_PF=$PIA_PF
 
 # Set this to the maximum allowed latency in seconds.
-# All servers that repond slower than this will be ignored.
+# All servers that respond slower than this will be ignored.
 echo -n "
 With no input, the maximum allowed latency will be set to 0.05s (50ms).
 If your connection has high latency, you may need to increase this value.

--- a/run_setup.sh
+++ b/run_setup.sh
@@ -103,11 +103,6 @@ PIA_DNS="true"
 if echo ${setDNS:0:1} | grep -iq n; then
   PIA_DNS="false"
 fi
-
-PIA_DNS="true"
-if  echo ${setDNS:0:1} | grep -iq n; then
-  PIA_DNS="false"
-fi
 export PIA_DNS
 echo PIA_DNS=$PIA_DNS"
 "

--- a/run_setup.sh
+++ b/run_setup.sh
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-# Only allow script to run as 
+# Only allow script to run as
 if [ "$(whoami)" != "root" ]; then
   echo "This script needs to be run as root. Try again with 'sudo $0'"
   exit 1
@@ -60,17 +60,17 @@ if echo ${connection_method:0:1} | grep -iq o; then
   echo -n "Connection method ([U]dp/[t]cp): "
   read protocolInput
   echo
-  
+
   protocol="udp"
   if echo ${protocolInput:0:1} | grep -iq t; then
     protocol="tcp"
   fi
-  
+
   echo "Higher levels of encryption trade performance for security. "
   echo -n "Do you want to use strong encryption ([N]o/[y]es): "
   read strongEncryption
   echo
-  
+
   encryption="standard"
   if echo ${strongEncryption:0:1} | grep -iq y; then
     encryption="strong"
@@ -98,7 +98,7 @@ if [ "$setDNS" != no ]; then
   read setDNS
   echo
 fi
-  
+
 PIA_DNS="true"
 if echo ${setDNS:0:1} | grep -iq n; then
   PIA_DNS="false"


### PR DESCRIPTION
Just passing through.

Was looking for an updated [`pia-nm.sh`](https://www.privateinternetaccess.com/installer/pia-nm.sh) script that uses NextGen servers. Found this repo. Took a look, turns out it does something different. Noticed some duplicated code and decided to fix it and run some usual checks on the repo.

A better configured text editor, spellcheck and [shellcheck](https://www.shellcheck.net/) would have prevented these.

The `<` to `-lt` change is because [`<` compares the operands in a lexicographical order, as a string, instead of comparing them as a number](https://github.com/koalaman/shellcheck/wiki/SC2071).

ShellCheck also says that a lot of stuff should preferably be quoted. I decided not to fix it as there is a good chance I could break something, so I leave this up for you to fix.

Have a good day.