### PR TITLE
Fix not correctly detecting existence of tun interface ( fixes #25 )

### DIFF
--- a/connect_to_openvpn_with_token.sh
+++ b/connect_to_openvpn_with_token.sh
@@ -37,10 +37,10 @@ check_tool openvpn
 # Check if manual PIA OpenVPN connection is already initialized.
 # Multi-hop is out of the scope of this repo, but you should be able to
 # get multi-hop running with both OpenVPN and WireGuard.
-adapter_check="$( ip a s tun06 )"
-should_read="Device \"tun06\" does not exist"
+adapter_check="$( ip a s tun06 2>&1 )"
+should_read_pattern="^[:space:]*Device \"tun06\" does not exist\\.?[:space:]*$"
 pid_filepath="/opt/piavpn-manual/pia_pid"
-if [[ "$adapter_check" != "$should_read" ]]; then
+if [[ ! "$adapter_check" =~ $should_read_pattern ]]; then
   echo The tun06 adapter already exists, that interface is required
   echo for this configuration.
   if [ -f "$pid_filepath" ]; then

--- a/connect_to_openvpn_with_token.sh
+++ b/connect_to_openvpn_with_token.sh
@@ -38,9 +38,9 @@ check_tool openvpn
 # Multi-hop is out of the scope of this repo, but you should be able to
 # get multi-hop running with both OpenVPN and WireGuard.
 adapter_check="$( ip a s tun06 2>&1 )"
-should_read_pattern="^[:space:]*Device \"tun06\" does not exist\\.?[:space:]*$"
+should_read="Device \"tun06\" does not exist"
 pid_filepath="/opt/piavpn-manual/pia_pid"
-if [[ ! "$adapter_check" =~ $should_read_pattern ]]; then
+if [[ "$adapter_check" != *"$should_read"* ]]; then
   echo The tun06 adapter already exists, that interface is required
   echo for this configuration.
   if [ -f "$pid_filepath" ]; then


### PR DESCRIPTION
Problem happens because of mishandling output of `ip` command.

for example on ubuntu 18.04:

- if interface doesn't exist `ip` sends the message to STDERR ( currently we read only it's STDOUT ). The change is to merge STDERR and STDOUT.
- On this system there is a slight difference in the message format. Just an extra period in the message but we were doing exact string comparison. msg: ( Device "tun06" does not exist. ). Our change is to be more flexible in reading the message and allow for extra whitespace and periods.