### PR TITLE
Port forward in existing vpn connection

### DIFF
--- a/get_region_and_token.sh
+++ b/get_region_and_token.sh
@@ -136,36 +136,7 @@ OpenVPN TCP: $bestServer_OT_IP // $bestServer_OT_hostname
 OpenVPN UDP: $bestServer_OU_IP // $bestServer_OU_hostname
 "
 
-if [[ ! $PIA_USER || ! $PIA_PASS ]]; then
-  echo If you want this script to automatically get a token from the Meta
-  echo service, please add the variables PIA_USER and PIA_PASS. Example:
-  echo $ PIA_USER=p0123456 PIA_PASS=xxx ./get_region_and_token.sh
-  exit 1
-fi
-
-echo "The ./get_region_and_token.sh script got started with PIA_USER and PIA_PASS,
-so we will also use a meta service to get a new VPN token."
-
-echo "Trying to get a new token by authenticating with the meta service..."
-generateTokenResponse=$(curl -s -u "$PIA_USER:$PIA_PASS" \
-  --connect-to "$bestServer_meta_hostname::$bestServer_meta_IP:" \
-  --cacert "ca.rsa.4096.crt" \
-  "https://$bestServer_meta_hostname/authv3/generateToken")
-echo "$generateTokenResponse"
-
-if [ "$(echo "$generateTokenResponse" | jq -r '.status')" != "OK" ]; then
-  echo "Could not get a token. Please check your account credentials."
-  echo
-  echo "You can also try debugging by manually running the curl command:"
-  echo $ curl -vs -u "$PIA_USER:$PIA_PASS" --cacert ca.rsa.4096.crt \
-    --connect-to "$bestServer_meta_hostname::$bestServer_meta_IP:" \
-    https://$bestServer_meta_hostname/authv3/generateToken
-  exit 1
-fi
-
-token="$(echo "$generateTokenResponse" | jq -r '.token')"
-echo "This token will expire in 24 hours.
-"
+token="$(./get_token.sh)"
 
 # just making sure this variable doesn't contain some strange string
 if [ "$PIA_PF" != true ]; then

--- a/get_region_and_token.sh
+++ b/get_region_and_token.sh
@@ -115,8 +115,8 @@ else
   echo "."
 fi
 echo
-bestServer_meta_IP="$(echo $regionData | jq -r '.servers.meta[0].ip')"
-bestServer_meta_hostname="$(echo $regionData | jq -r '.servers.meta[0].cn')"
+export PIA_SERVER_META_IP="$(echo $regionData | jq -r '.servers.meta[0].ip')"
+export PIA_SERVER_META_HOSTNAME="$(echo $regionData | jq -r '.servers.meta[0].cn')"
 bestServer_WG_IP="$(echo $regionData | jq -r '.servers.wg[0].ip')"
 bestServer_WG_hostname="$(echo $regionData | jq -r '.servers.wg[0].cn')"
 bestServer_OT_IP="$(echo $regionData | jq -r '.servers.ovpntcp[0].ip')"
@@ -130,13 +130,18 @@ the SSL/TLS certificate actually contains the hostname so that you
 are sure you are connecting to a secure server, validated by the
 PIA authority. Please find bellow the list of best IPs and matching
 hostnames for each protocol:
-Meta Services: $bestServer_meta_IP // $bestServer_meta_hostname
+Meta Services: $PIA_SERVER_META_IP // $PIA_SERVER_META_HOSTNAME
 WireGuard: $bestServer_WG_IP // $bestServer_WG_hostname
 OpenVPN TCP: $bestServer_OT_IP // $bestServer_OT_hostname
 OpenVPN UDP: $bestServer_OU_IP // $bestServer_OU_hostname
 "
 
 token="$(./get_token.sh)"
+
+if [[ -z "$token" ]]; then
+  echo "Error: Could not get token."
+  exit 1
+fi
 
 # just making sure this variable doesn't contain some strange string
 if [ "$PIA_PF" != true ]; then

--- a/get_token.sh
+++ b/get_token.sh
@@ -1,30 +1,56 @@
-if [[ ! $PIA_USER || ! $PIA_PASS ]]; then
-  echo If you want this script to automatically get a token from the Meta
-  echo service, please add the variables PIA_USER and PIA_PASS. Example:
-  echo $ PIA_USER=p0123456 PIA_PASS=xxx ./get_region_and_token.sh
+#!/bin/bash
+# Copyright (C) 2020 Private Internet Access, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+if [[ ! $PIA_USER || ! $PIA_PASS || ! $PIA_SERVER_META_IP || ! $PIA_SERVER_META_HOSTNAME ]]; then
+  1>&2 echo If you want this script to automatically get a token from
+  1>&2 echo the Meta service, please add the variables PIA_USER,
+  1>&2 echo PIA_PASS, PIA_SERVER_META_IP, and PIA_SERVER_META_HOSTNAME.
+  1>&2 echo Example:
+  1>&2 echo $ PIA_USER=p0123456 PIA_PASS=xxx PIA_SERVER_META_IP=x.x.x.x 
+  1>&2 echo PIA_SERVER_META_HOSTNAME=xxx ./get_token.sh
   exit 1
 fi
 
-echo "The ./get_region_and_token.sh script got started with PIA_USER and PIA_PASS,
-so we will also use a meta service to get a new VPN token."
+1>&2 echo "The ./get_token.sh script got started with PIA_USER and PIA_PASS and PIA_SERVER_META_HOSTNAME and PIA_SERVER_META_IP,
+ so we will also use a meta service to get a new VPN token."
 
-echo "Trying to get a new token by authenticating with the meta service..."
+1>&2 echo "Trying to get a new token by authenticating with the meta service..."
 generateTokenResponse=$(curl -s -u "$PIA_USER:$PIA_PASS" \
-  --connect-to "$bestServer_meta_hostname::$bestServer_meta_IP:" \
+  --connect-to "$PIA_SERVER_META_HOSTNAME::$PIA_SERVER_META_IP:" \
   --cacert "ca.rsa.4096.crt" \
-  "https://$bestServer_meta_hostname/authv3/generateToken")
-echo "$generateTokenResponse"
+  "https://$PIA_SERVER_META_HOSTNAME/authv3/generateToken")
+1>&2 echo "$generateTokenResponse"
 
 if [ "$(echo "$generateTokenResponse" | jq -r '.status')" != "OK" ]; then
-  echo "Could not get a token. Please check your account credentials."
-  echo
-  echo "You can also try debugging by manually running the curl command:"
-  echo $ curl -vs -u "$PIA_USER:$PIA_PASS" --cacert ca.rsa.4096.crt \
-    --connect-to "$bestServer_meta_hostname::$bestServer_meta_IP:" \
-    https://$bestServer_meta_hostname/authv3/generateToken
+  1>&2 echo "Could not get a token. Please check your account credentials."
+  1>&2 echo
+  1>&2 echo "You can also try debugging by manually running the curl command:"
+  1>&2 echo $ curl -vs -u "$PIA_USER:$PIA_PASS" --cacert ca.rsa.4096.crt \
+    --connect-to "$PIA_SERVER_META_HOSTNAME::$PIA_SERVER_META_IP:" \
+    https://$PIA_SERVER_META_HOSTNAME/authv3/generateToken
   exit 1
 fi
 
 token="$(echo "$generateTokenResponse" | jq -r '.token')"
-echo "This token will expire in 24 hours.
+1>&2 echo "This token will expire in 24 hours.
 "
+
+echo $token

--- a/get_token.sh
+++ b/get_token.sh
@@ -1,0 +1,30 @@
+if [[ ! $PIA_USER || ! $PIA_PASS ]]; then
+  echo If you want this script to automatically get a token from the Meta
+  echo service, please add the variables PIA_USER and PIA_PASS. Example:
+  echo $ PIA_USER=p0123456 PIA_PASS=xxx ./get_region_and_token.sh
+  exit 1
+fi
+
+echo "The ./get_region_and_token.sh script got started with PIA_USER and PIA_PASS,
+so we will also use a meta service to get a new VPN token."
+
+echo "Trying to get a new token by authenticating with the meta service..."
+generateTokenResponse=$(curl -s -u "$PIA_USER:$PIA_PASS" \
+  --connect-to "$bestServer_meta_hostname::$bestServer_meta_IP:" \
+  --cacert "ca.rsa.4096.crt" \
+  "https://$bestServer_meta_hostname/authv3/generateToken")
+echo "$generateTokenResponse"
+
+if [ "$(echo "$generateTokenResponse" | jq -r '.status')" != "OK" ]; then
+  echo "Could not get a token. Please check your account credentials."
+  echo
+  echo "You can also try debugging by manually running the curl command:"
+  echo $ curl -vs -u "$PIA_USER:$PIA_PASS" --cacert ca.rsa.4096.crt \
+    --connect-to "$bestServer_meta_hostname::$bestServer_meta_IP:" \
+    https://$bestServer_meta_hostname/authv3/generateToken
+  exit 1
+fi
+
+token="$(echo "$generateTokenResponse" | jq -r '.token')"
+echo "This token will expire in 24 hours.
+"

--- a/port_forwarding_in_existing.sh
+++ b/port_forwarding_in_existing.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Copyright (C) 2020 Private Internet Access, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+if [[ ! $PIA_USER || ! $PIA_PASS || ! $PIA_HOSTNAME || ! $PIA_GATEWAY ]]; then
+  echo 'This script requires 4 env vars:'
+  echo 'PIA_USER            - PIA username'
+  echo 'PIA_PASS            - PIA password'
+  echo 'PIA_HOSTNAME        - name of the server, required for ssl'
+  echo 'PIA_GATEWAY         - the vpn gateway you are connected to.'
+  exit 1
+fi
+
+token="$(PIA_SERVER_META_HOSTNAME=$PIA_HOSTNAME \
+  PIA_SERVER_META_IP=10.0.0.1 \
+  PIA_USER=$PIA_USER \
+  PIA_PASS=$PIA_PASS \
+  ./get_token.sh)"
+
+if [[ -z "$token" ]]; then
+  echo "Error: Could not get token."
+  exit 1
+fi
+
+PIA_TOKEN="$token" \
+  PF_GATEWAY="$PIA_GATEWAY" \
+  PF_HOSTNAME="$PIA_HOSTNAME" \
+  ./port_forwarding.sh


### PR DESCRIPTION
Fixes #35 . Adds an extra script ```port_forwarding_in_existing.sh```. Also splits off ```get_token```, which should make it easier for those without bash experience to customize this repo for their setup. 

Potential issues:

- ```port_forwarding_in_existing.sh``` assumes that the hostname of the Meta Services server is identical to that of the endpoint

Only tested on Ubuntu 18.04. If the PR is thought good, I'll test on more systems when I can. Or in the meantime, if some kind soul wants to help by testing it on their own system, that would be lovely. 😊

To test:

- Connect to the vpn using ```get_region_and_token``` (or ```run_setup``` if you prefer) but don't enable port forwarding.
  - If this script doesn't function on your system you can skip it. I seem to remember some systems like freebsd can't run some of these scripts out-of-the-box.
- when connected to vpn, test ```port_forwarding_in_existing.sh```. Can run it without vars and it will tell you what it needs, then run it for real.