### PR TITLE
connect_to_openvpn_with_token.sh: Consider configuration where IPv6 has been disabled via kernel cmdline param

### DIFF
--- a/connect_to_openvpn_with_token.sh
+++ b/connect_to_openvpn_with_token.sh
@@ -66,8 +66,11 @@ fi
 
 # PIA currently does not support IPv6. In order to be sure your VPN
 # connection does not leak, it is best to disabled IPv6 altogether.
-if [ $(sysctl -n net.ipv6.conf.all.disable_ipv6) -ne 1 ] ||
-  [ $(sysctl -n net.ipv6.conf.default.disable_ipv6) -ne 1 ]
+# IPv6 can also be disabled via kernel commandline param, so we must
+# first check if this is the case.
+if [[ -f /proc/net/if_inet6 ]] &&
+  [[ $(sysctl -n net.ipv6.conf.all.disable_ipv6) -ne 1 ||
+     $(sysctl -n net.ipv6.conf.default.disable_ipv6) -ne 1 ]]
 then
   echo 'You should consider disabling IPv6 by running:'
   echo 'sysctl -w net.ipv6.conf.all.disable_ipv6=1'

--- a/connect_to_wireguard_with_token.sh
+++ b/connect_to_wireguard_with_token.sh
@@ -37,8 +37,11 @@ check_tool jq jq
 
 # PIA currently does not support IPv6. In order to be sure your VPN
 # connection does not leak, it is best to disabled IPv6 altogether.
-if [ $(sysctl -n net.ipv6.conf.all.disable_ipv6) -ne 1 ] ||
-  [ $(sysctl -n net.ipv6.conf.default.disable_ipv6) -ne 1 ]
+# IPv6 can also be disabled via kernel commandline param, so we must
+# first check if this is the case.
+if [[ -f /proc/net/if_inet6 ]] &&
+  [[ $(sysctl -n net.ipv6.conf.all.disable_ipv6) -ne 1 ||
+     $(sysctl -n net.ipv6.conf.default.disable_ipv6) -ne 1 ]]
 then
   echo 'You should consider disabling IPv6 by running:'
   echo 'sysctl -w net.ipv6.conf.all.disable_ipv6=1'


### PR DESCRIPTION
The check:

```sh
if [ $(sysctl -n net.ipv6.conf.all.disable_ipv6) -ne 1 ] ||
  [ $(sysctl -n net.ipv6.conf.default.disable_ipv6) -ne 1 ]
```

assumes that ipv6 is supported.

If IPv6 has been disabled via kernel cmdline parameter (`ipv6.disable=1`), the check will fail with an error.

This commit fixes the test.

Closes https://github.com/pia-foss/manual-connections/issues/42.