### PR TITLE
Make the OpenVPN credentials file readable only by root

### DIFF
--- a/connect_to_openvpn_with_token.sh
+++ b/connect_to_openvpn_with_token.sh
@@ -108,6 +108,7 @@ mkdir -p /opt/piavpn-manual
 rm -f /opt/piavpn-manual/credentials /opt/piavpn-manual/route_info
 echo ${PIA_TOKEN:0:62}"
 "${PIA_TOKEN:62} > /opt/piavpn-manual/credentials || exit 1
+chmod 600 /opt/piavpn-manual/credentials
 
 # Translate connection settings variable
 IFS='_'


### PR DESCRIPTION
It previously was world-readable (0644 permissions).

Closes #45.