### PR TITLE
Use numeric sort to select regions.

### DIFF
--- a/get_region_and_token.sh
+++ b/get_region_and_token.sh
@@ -93,7 +93,7 @@ echo Testing regions that respond \
   faster than $MAX_LATENCY seconds:
 bestRegion="$(echo "$summarized_region_data" |
   xargs -I{} bash -c 'printServerLatency {}' |
-  sort | head -1 | awk '{ print $2 }')"
+  sort -n | head -1 | awk '{ print $2 }')"
 
 if [ -z "$bestRegion" ]; then
   echo ...


### PR DESCRIPTION
`sort -n` will compare the numeric results of `printServerLatency`. The
existing script uses lexical comparison, and therefore does not
necessarily select the best region.