### PR TITLE
Append triffid/pia-wg to 3rd party repository table

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Some users have created their own repositories for manual connections, based on 
 |:-:|:-:|:-:|:-:|-|
 | FreeBSD | Yes | Bash | Compatibility | [glorious1/manual-connections](https://github.com/glorious1/manual-connections) |
 | Linux | No | Python | WireGuard, PF | [milahu/python-piavpn](https://github.com/milahu/python-piavpn) |
+| Linux | No | Bash | WireGuard, PF | [triffid/pia-wg](https://github.com/triffid/pia-wg) <br />can generate configs for routers and [WireGuard's android/iOS app](https://www.wireguard.com/install/#android-play-store-f-droid) |
 | OPNsense | No | Python | WireGuard, PF | [FingerlessGlov3s/OPNsensePIAWireguard](https://github.com/FingerlessGlov3s/OPNsensePIAWireguard) |
 | pfSense | No | Sh | OpenVPN, PF | [fm407/PIA-NextGen-PortForwarding](https://github.com/fm407/PIA-NextGen-PortForwarding) |
 | pfSense | No | Java/PHP | WireGuard, PF | [ddb_db/pfpiamgr](https://gitlab.com/ddb_db/pfpiamgr) |
@@ -65,7 +66,6 @@ Some users have created their own repositories for manual connections, based on 
 | Synology | No | Python | PF | [stmty9/synology](https://github.com/stmty9/synology) |
 | TrueNAS | No | Bash | PF | [dak180/TrueNAS-Scripts](https://github.com/dak180/TrueNAS-Scripts/blob/master/pia-port-forward.sh) |
 | UFW | Yes | Bash | Firewall Rules | [iPherian/manual-connections](https://github.com/iPherian/manual-connections) |
-| Linux | No | Bash | WireGuard, PF | [triffid/pia-wg](https://github.com/triffid/pia-wg) |
 
 ## PIA Port Forwarding
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Some users have created their own repositories for manual connections, based on 
 | Synology | No | Python | PF | [stmty9/synology](https://github.com/stmty9/synology) |
 | TrueNAS | No | Bash | PF | [dak180/TrueNAS-Scripts](https://github.com/dak180/TrueNAS-Scripts/blob/master/pia-port-forward.sh) |
 | UFW | Yes | Bash | Firewall Rules | [iPherian/manual-connections](https://github.com/iPherian/manual-connections) |
+| Linux | No | Bash | WireGuard, PF | [triffid/pia-wg](https://github.com/triffid/pia-wg) |
 
 ## PIA Port Forwarding
 


### PR DESCRIPTION
I've formalised my [old gist](https://gist.github.com/triffid/da48f3c99f1ff334571ae49be80d591b) into [a proper repository](https://github.com/triffid/pia-wg).

My scripts are designed to act more like a proper system service than PIA's manual-connection scripts, in that they use a config file, a proper cache location, can reuse cached link information, can set up routing tables and ip rules that can assist with customised split-routing setups, do more error checking, and do not require DNS after the initial cache fill procedure.

They're also capable of generating configs for other devices instead of only affecting the device on which they're run, and can even drop a QR code onto the terminal for use with [WireGuard's Android app](https://www.wireguard.com/install/#android-play-store-f-droid) (and probably the iOS app too but I haven't tried).