### PR TITLE
Fix the hasbang so it works on FreeBSD

### DIFF
--- a/connect_to_openvpn_with_token.sh
+++ b/connect_to_openvpn_with_token.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (C) 2020 Private Internet Access, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/connect_to_wireguard_with_token.sh
+++ b/connect_to_wireguard_with_token.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (C) 2020 Private Internet Access, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/get_region.sh
+++ b/get_region.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (C) 2020 Private Internet Access, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/get_token.sh
+++ b/get_token.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (C) 2020 Private Internet Access, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/openvpn_config/openvpn_down.sh
+++ b/openvpn_config/openvpn_down.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Remove process and route information when connection closes
 rm -rf /opt/piavpn-manual/pia_pid /opt/pia-manual/route_info

--- a/openvpn_config/openvpn_down_dnsoverwrite.sh
+++ b/openvpn_config/openvpn_down_dnsoverwrite.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Remove process and route information when connection closes
 rm -rf /opt/piavpn-manual/pia_pid /opt/pia-manual/route_info

--- a/openvpn_config/openvpn_up.sh
+++ b/openvpn_config/openvpn_up.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Write gateway IP for reference
 echo $route_vpn_gateway > /opt/piavpn-manual/route_info

--- a/openvpn_config/openvpn_up_dnsoverwrite.sh
+++ b/openvpn_config/openvpn_up_dnsoverwrite.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Write gateway IP for reference
 echo $route_vpn_gateway > /opt/piavpn-manual/route_info

--- a/port_forwarding.sh
+++ b/port_forwarding.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (C) 2020 Private Internet Access, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/run_setup.sh
+++ b/run_setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (C) 2020 Private Internet Access, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
On my FreeBSD system bash is at /usr/local/bin/bash
By using the hasbang `$!/usr/bin/env bash` it works on
any system