### PR TITLE
Raspberry-pi: Automatically add iptables entries when wg interface is created.

### DIFF
--- a/connect_to_wireguard_with_token.sh
+++ b/connect_to_wireguard_with_token.sh
@@ -130,11 +130,30 @@ if [ "$PIA_DNS" == true ]; then
 fi
 echo -n "Trying to write /etc/wireguard/pia.conf..."
 mkdir -p /etc/wireguard
+
 echo "
 [Interface]
 Address = $(echo "$wireguard_json" | jq -r '.peer_ip')
 PrivateKey = $privKey
 $dnsSettingForVPN
+PostUp = iptables -I INPUT -i eth0 -m comment --comment 'In from LAN' -j ACCEPT; \
+iptables -I OUTPUT -o pia -m comment --comment 'Out to VPN' -j ACCEPT; \
+iptables -A OUTPUT -o eth0 -p udp --dport 1337 -m comment --comment 'wireguard' -j ACCEPT; \
+iptables -A OUTPUT -o eth0 -p udp --dport 123 -m comment --comment 'ntp' -j ACCEPT; \
+iptables -A OUTPUT -o eth0 -p udp --dport 53 -m comment --comment 'dns' -j ACCEPT; \
+iptables -A FORWARD -i pia -o eth0 -m state --state RELATED,ESTABLISHED -j ACCEPT; \
+iptables -A FORWARD -i eth0 -o pia -m comment --comment 'LAN out to VPN' -j ACCEPT; \
+iptables -t nat -A POSTROUTING -o pia -j MASQUERADE
+
+PostDown = iptables -D INPUT -i eth0 -m comment --comment 'In from LAN' -j ACCEPT; \
+iptables -D OUTPUT -o pia -m comment --comment 'Out to VPN' -j ACCEPT; \
+iptables -D OUTPUT -o eth0 -p udp --dport 1337 -m comment --comment 'wireguard' -j ACCEPT; \
+iptables -D OUTPUT -o eth0 -p udp --dport 123 -m comment --comment 'ntp' -j ACCEPT; \
+iptables -D OUTPUT -o eth0 -p udp --dport 53 -m comment --comment 'dns' -j ACCEPT; \
+iptables -D FORWARD -i pia -o eth0 -m state --state RELATED,ESTABLISHED -j ACCEPT; \
+iptables -D FORWARD -i eth0 -o pia -m comment --comment 'LAN out to VPN' -j ACCEPT; \
+iptables -t nat -D POSTROUTING -o pia -j MASQUERADE
+
 [Peer]
 PersistentKeepalive = 25
 PublicKey = $(echo "$wireguard_json" | jq -r '.server_key')


### PR DESCRIPTION
## This has only been tested in Raspberry 4 ##

When the connection is created, iptables will also be modified so that traffic from LAN can be forwarded to the wireguard pia interface created. If that interface is taken down, iptables entries added will be removed as well.

For a successful forwarding, ip_forwarding has to be enabled globally as well by uncommenting the line `net.ipv4.ip_forward = 1` in /etc/sysctl.conf file and making it persistent with `sudo sysctl -p`. This paragraph isn't part of the PR though.