### PR TITLE
updated AllowedIPs to fix iptables errors

### DIFF
--- a/connect_to_wireguard_with_token.sh
+++ b/connect_to_wireguard_with_token.sh
@@ -138,7 +138,7 @@ $dnsSettingForVPN
 [Peer]
 PersistentKeepalive = 25
 PublicKey = $(echo "$wireguard_json" | jq -r '.server_key')
-AllowedIPs = 0.0.0.0/0
+AllowedIPs = 0.0.0.0/1, 128.0.0.0/1
 Endpoint = ${WG_SERVER_IP}:$(echo "$wireguard_json" | jq -r '.server_port')
 " > /etc/wireguard/pia.conf || exit 1
 echo -e ${GREEN}OK!${NC}


### PR DESCRIPTION
Having the acceptIPs token set to `0.0.0.0/0` can cause errors (as seen [here](https://github.com/linuxserver/docker-wireguard/issues/60)

This can be fixed by setting the token to `0.0.0.0/1, 128.0.0.0/1` which is functionally the same but prevents iptables from complaining.