### PR TITLE
Exit with error upon failure to get token

### DIFF
--- a/get_token.sh
+++ b/get_token.sh
@@ -79,7 +79,7 @@ if [ "$(echo "$generateTokenResponse" | jq -r '.token')" == "" ]; then
   echo
   echo -e "${red}Could not authenticate with the login credentials provided!${nc}"
   echo
-  exit
+  exit 1
 fi
 
 echo -e "${green}OK!"


### PR DESCRIPTION
When there's a failure to get the token from https://www.privateinternetaccess.com/api/client/v2/token exit with an error status of 1 instead of success