### PR TITLE
When token service fails, display the error

### DIFF
--- a/get_token.sh
+++ b/get_token.sh
@@ -69,10 +69,18 @@ fi
 
 echo -n "Checking login credentials..."
 
-generateTokenResponse=$(curl -s --location --request POST \
+generateTokenResponse=$(curl --fail-with-body -s --location --request POST \
   'https://www.privateinternetaccess.com/api/client/v2/token' \
   --form "username=$PIA_USER" \
-  --form "password=$PIA_PASS" )
+  --form "password=$PIA_PASS" ) || {
+    echo
+    echo -e "${red}Could not authenticate with the login credentials provided!${nc}"
+    echo "Error response:"
+    echo $generateTokenResponse
+    echo
+    exit 1
+}
+
 
 if [ "$(echo "$generateTokenResponse" | jq -r '.token')" == "" ]; then
   echo


### PR DESCRIPTION
When https://www.privateinternetaccess.com/api/client/v2/token fails, such as with an "504 Gateway Time-out" error, display that error so the user knows what happened.