### PR TITLE
Use URL encoding for password

### DIFF
--- a/get_token.sh
+++ b/get_token.sh
@@ -71,8 +71,8 @@ echo -n "Checking login credentials..."
 
 generateTokenResponse=$(curl -s --location --request POST \
   'https://www.privateinternetaccess.com/api/client/v2/token' \
-  --form "username=$PIA_USER" \
-  --form "password=$PIA_PASS" )
+  --data-urlencode "username=$PIA_USER" \
+  --data-urlencode "password=$PIA_PASS" )
 
 if [ "$(echo "$generateTokenResponse" | jq -r '.token')" == "" ]; then
   echo


### PR DESCRIPTION
Use URL encoding for password during token request to properly handle passwords with special characters in them such as **&** etc