### PR TITLE
Add Privateerr to third-party repository list

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Some users have created their own repositories for manual connections, based on 
 | Linux | No | Go | WireGuard via systemd-networkd, PF | [jdelkins/pia-tools](https://github.com/jdelkins/pia-tools) |
 | Linux/FreeBSD/Win | No | Go | WireGuard,<br />config generation | [ddb_db/piawgcli](https://gitlab.com/ddb_db/piawgcli) |
 | OPNsense | No | Python | WireGuard, PF, DIP | [FingerlessGlov3s/OPNsensePIAWireguard](https://github.com/FingerlessGlov3s/OPNsensePIAWireguard) |
+| Docker | No | Docker Compose | WireGuard,<br />config generation | [scottgigawatt/privateerr](https://github.com/scottgigawatt/privateerr) |
 | pfSense | No | Sh | OpenVPN, PF | [fm407/PIA-NextGen-PortForwarding](https://github.com/fm407/PIA-NextGen-PortForwarding) |
 | pfSense | No | Java/PHP | WireGuard, PF | [ddb_db/pfpiamgr](https://gitlab.com/ddb_db/pfpiamgr) |
 | Synology | Yes | Bash | Compatibility | [steff2632/manual-connections](https://github.com/steff2632/manual-connections) |

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Some users have created their own repositories for manual connections, based on 
 | Linux | No | Go | WireGuard via systemd-networkd, PF | [jdelkins/pia-tools](https://github.com/jdelkins/pia-tools) |
 | Linux/FreeBSD/Win | No | Go | WireGuard,<br />config generation | [ddb_db/piawgcli](https://gitlab.com/ddb_db/piawgcli) |
 | OPNsense | No | Python | WireGuard, PF, DIP | [FingerlessGlov3s/OPNsensePIAWireguard](https://github.com/FingerlessGlov3s/OPNsensePIAWireguard) |
-| Docker | No | Docker Compose | WireGuard,<br />config generation | [scottgigawatt/privateerr](https://github.com/scottgigawatt/privateerr) |
+| Docker/Linux/Synology | No | Sh, Bash, Docker Compose | WireGuard, PF, DIP, config generation | [☠ scottgigawatt/privateerr ☠](https://github.com/scottgigawatt/privateerr) |
 | pfSense | No | Sh | OpenVPN, PF | [fm407/PIA-NextGen-PortForwarding](https://github.com/fm407/PIA-NextGen-PortForwarding) |
 | pfSense | No | Java/PHP | WireGuard, PF | [ddb_db/pfpiamgr](https://gitlab.com/ddb_db/pfpiamgr) |
 | Synology | Yes | Bash | Compatibility | [steff2632/manual-connections](https://github.com/steff2632/manual-connections) |


### PR DESCRIPTION
## Add Privateerr to third-party repository list

Adds [scottgigawatt/privateerr](https://github.com/scottgigawatt/privateerr) to the 3rd Party Repositories table.

Privateerr packages this repository’s PIA manual connection scripts 100% unaltered into a small, multi-architecture Alpine-based Docker image. It uses Docker Compose to make WireGuard configuration generation easier to run in containerized environments while preserving the upstream scripts exactly as-is.

Built image:

```console
ghcr.io/scottgigawatt/privateerr:latest
```